### PR TITLE
Update the default lavalink server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 TOKEN=000000000000000000
 PREFIX=,
 OWNER_ID=190190190190190190
-LAVA_HOST=localhost
-LAVA_PORT=2333
+LAVA_HOST=lava.link
+LAVA_PORT=80
 LAVA_PASS=youshallnotpass
 ENABLE_SPOTIFY=false
 # you will need these if you enabled spotify


### PR DESCRIPTION
It seems that a lot of new developers are experiencing issues hosting their lavalink instance.

Here's a free lavalink instance [https://support.something.host/en/article/lavalink-hosting-okm26z/](https://support.something.host/en/article/lavalink-hosting-okm26z/)